### PR TITLE
Example: Track port connections and gobal/local port requests by ids

### DIFF
--- a/examples/basic-web-extension/background-script/Cargo.toml
+++ b/examples/basic-web-extension/background-script/Cargo.toml
@@ -12,6 +12,7 @@ gloo-console = "0.2.1"
 js-sys = "0.3.58"
 messages = { version = "0.0.0", path = "../messages" }
 serde = { version = "1.0.137", features = ["derive"] }
+thiserror = "1.0.31"
 wasm-bindgen = { version = "0.2.81", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.31"
 web-extensions-sys = "0.1.0"

--- a/examples/basic-web-extension/background-script/Cargo.toml
+++ b/examples/basic-web-extension/background-script/Cargo.toml
@@ -9,6 +9,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 gloo-console = "0.2.1"
+gloo-timers = { version = "0.2.4", features = ["futures"] }
 js-sys = "0.3.58"
 messages = { version = "0.0.0", path = "../messages" }
 serde = { version = "1.0.137", features = ["derive"] }

--- a/examples/basic-web-extension/background-script/src/lib.rs
+++ b/examples/basic-web-extension/background-script/src/lib.rs
@@ -369,7 +369,7 @@ fn handle_port_request(
                                 // Delay the next (or final) response. Without yielding at some point
                                 // the locally spawned task would finish before the started response
                                 // could be posted.
-                                TimeoutFuture::new(1).await;
+                                TimeoutFuture::new(5_000).await;
                             }
                             console::debug!("Finish streaming");
                             let status = if last_item_index.unwrap_or(num_items) < num_items {

--- a/examples/basic-web-extension/foreground-script/src/lib.rs
+++ b/examples/basic-web-extension/foreground-script/src/lib.rs
@@ -19,6 +19,10 @@ pub fn start() {
     let payload = messages::PortRequestPayload::Ping;
     let msg = JsValue::from_serde(&messages::Request::new(payload)).unwrap();
     port.post_message(&msg);
+
+    let payload = messages::PortRequestPayload::StartStreaming { num_items: 5 };
+    let msg = JsValue::from_serde(&messages::Request::new(payload)).unwrap();
+    port.post_message(&msg);
 }
 
 fn render_container() {

--- a/examples/basic-web-extension/foreground-script/src/lib.rs
+++ b/examples/basic-web-extension/foreground-script/src/lib.rs
@@ -16,7 +16,8 @@ pub fn start() {
     let callback = closure.as_ref().unchecked_ref();
     port.on_message().add_listener(callback);
     closure.forget();
-    let msg = JsValue::from_serde(&messages::PortRequest::Ping).unwrap();
+    let payload = messages::PortRequestPayload::Ping;
+    let msg = JsValue::from_serde(&messages::Request::new(payload)).unwrap();
     port.post_message(&msg);
 }
 

--- a/examples/basic-web-extension/messages/src/lib.rs
+++ b/examples/basic-web-extension/messages/src/lib.rs
@@ -1,37 +1,133 @@
 use serde::{Deserialize, Serialize};
 
-/// Global request message.
+pub type RequestId = usize;
+
+pub const FIRST_REQUEST_ID: RequestId = 1;
+
+pub const INITIAL_REQUEST_ID: RequestId = FIRST_REQUEST_ID - 1;
+
+pub fn next_request_id(last_request_id: RequestId) -> RequestId {
+    last_request_id.wrapping_add(1).max(FIRST_REQUEST_ID)
+}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct RequestHeader {
+    pub client_id: Option<String>,
+}
+
+impl RequestHeader {
+    pub const fn new() -> Self {
+        Self { client_id: None }
+    }
+
+    pub fn into_response(self, request_id: RequestId) -> ResponseHeader {
+        let Self { client_id } = self;
+        ResponseHeader {
+            client_id,
+            request_id,
+        }
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
-pub enum Request {
+pub struct Request<T> {
+    pub header: RequestHeader,
+    pub payload: T,
+}
+
+impl<T> Request<T> {
+    pub const fn new(payload: T) -> Self {
+        Self {
+            header: RequestHeader::new(),
+            payload,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ResponseHeader {
+    pub client_id: Option<String>,
+    pub request_id: RequestId,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Response<T> {
+    pub header: ResponseHeader,
+    pub payload: T,
+}
+
+/// App request message.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum AppRequestPayload {
     GetOptionsInfo,
 }
 
-/// Global response message.
+pub type AppRequest = Request<AppRequestPayload>;
+
+/// App response message.
 #[derive(Debug, Serialize, Deserialize)]
-pub enum Response {
+pub enum AppResponsePayload {
     OptionsInfo { version: String },
 }
 
+pub type AppResponse = Response<AppResponsePayload>;
+
 /// Port-local request message.
 #[derive(Debug, Serialize, Deserialize)]
-pub enum PortRequest {
+pub enum PortRequestPayload {
     Ping,
-    StreamingExample,
+    StartStreaming { num_items: usize },
 }
+
+pub type PortRequest = Request<PortRequestPayload>;
 
 /// Port-local response message.
 #[derive(Debug, Serialize, Deserialize)]
-pub enum PortResponse {
+pub enum PortResponsePayload {
     Pong,
-    StreamingExample(StreamResponse),
+    Streaming(StreamingResponsePayload),
+}
+
+pub type PortResponse = Response<PortResponsePayload>;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum StreamingStarted {
+    /// The request has been accepted and will be processed.
+    Accepted,
+    /// The request has been rejected.
+    Rejected {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum StreamResponse {
-    /// The request was accepted
-    Accepted,
-    /// A streaming item
-    Item { item_number: usize },
-    /// The operation has finished.
-    Finished,
+pub enum StreamingFinished {
+    /// Processing has been completed.
+    Completed,
+    /// Processing has been aborted prematurely.
+    Aborted {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum StreamingResponsePayload {
+    Started {
+        started: StreamingStarted,
+    },
+    /// A streaming item.
+    ///
+    /// Items are sequentially numbered by a 0-based index
+    /// and might be received out of order.
+    Item {
+        index: usize,
+    },
+    /// Request processing has finished.
+    Finished {
+        finished: StreamingFinished,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        last_item_index: Option<usize>,
+    },
 }

--- a/examples/basic-web-extension/messages/src/lib.rs
+++ b/examples/basic-web-extension/messages/src/lib.rs
@@ -91,7 +91,7 @@ pub enum PortResponsePayload {
 pub type PortResponse = Response<PortResponsePayload>;
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum StreamingStarted {
+pub enum StreamingStartedStatus {
     /// The request has been accepted and will be processed.
     Accepted,
     /// The request has been rejected.
@@ -102,7 +102,7 @@ pub enum StreamingStarted {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub enum StreamingFinished {
+pub enum StreamingFinishedStatus {
     /// Processing has been completed.
     Completed,
     /// Processing has been aborted prematurely.
@@ -115,7 +115,7 @@ pub enum StreamingFinished {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum StreamingResponsePayload {
     Started {
-        started: StreamingStarted,
+        status: StreamingStartedStatus,
     },
     /// A streaming item.
     ///
@@ -126,7 +126,7 @@ pub enum StreamingResponsePayload {
     },
     /// Request processing has finished.
     Finished {
-        finished: StreamingFinished,
+        status: StreamingFinishedStatus,
         #[serde(skip_serializing_if = "Option::is_none")]
         last_item_index: Option<usize>,
     },


### PR DESCRIPTION
Assign identifiers to various contextual operations:

- Managing port connections
- Handling global requests
- Handling local port requests

 @flosse This is over-engineered without a concrete use case ;) At least it demonstrates which contexts might be of interest. More than you would first expect.