### PR TITLE
src/storage.rs: add SessionStorage

### DIFF
--- a/src/storage.rs
+++ b/src/storage.rs
@@ -38,6 +38,9 @@ extern "C" {
     #[wasm_bindgen(extends = StorageAreaWrite)]
     pub type Local;
 
+    #[wasm_bindgen(extends = StorageAreaWrite)]
+    pub type SessionStorage;
+
     #[wasm_bindgen(extends = StorageAreaRead)]
     pub type Managed;
 }
@@ -51,6 +54,9 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     pub fn local(this: &Storage) -> Local;
+
+    #[wasm_bindgen(method, getter)]
+    pub fn session(this: &Storage) -> SessionStorage;
 
     #[wasm_bindgen(method, getter)]
     pub fn managed(this: &Storage) -> Managed;


### PR DESCRIPTION
I've noticed that `storage.session` was missing from the `storage` module, so added it there (a storage type and a session method).
Unfortunately the short `Session` name is conflicting with the `sessions` mod, so had to add an ugly :)  `Storage` to the name (or maybe it'd be better to move all storage APIs behind a `::storage::`?)
