### PR TITLE
src/storage.rs: add session and regroup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use theme::*;
 pub use windows::*;
 
 pub mod traits {
-    pub use crate::storage::{StorageAreaRead, StorageAreaWrite};
+    pub use crate::storage::{StorageAreaRead, StorageArea};
 }
 
 #[wasm_bindgen]

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -18,31 +18,16 @@ extern "C" {
 #[wasm_bindgen]
 extern "C" {
     #[wasm_bindgen(extends = StorageAreaRead)]
-    pub type StorageAreaWrite;
+    pub type StorageArea;
 
     #[wasm_bindgen(catch, method)]
-    pub async fn set(this: &StorageAreaWrite, keys: &Object) -> Result<JsValue, JsValue>;
+    pub async fn set(this: &StorageArea, keys: &Object) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(catch, method)]
-    pub async fn remove(this: &StorageAreaWrite, keys: &JsValue) -> Result<JsValue, JsValue>;
+    pub async fn remove(this: &StorageArea, keys: &JsValue) -> Result<JsValue, JsValue>;
 
     #[wasm_bindgen(catch, method)]
-    pub async fn clear(this: &StorageAreaWrite) -> Result<JsValue, JsValue>;
-}
-
-#[wasm_bindgen]
-extern "C" {
-    #[wasm_bindgen(extends = StorageAreaWrite)]
-    pub type Sync;
-
-    #[wasm_bindgen(extends = StorageAreaWrite)]
-    pub type Local;
-
-    #[wasm_bindgen(extends = StorageAreaWrite)]
-    pub type SessionStorage;
-
-    #[wasm_bindgen(extends = StorageAreaRead)]
-    pub type Managed;
+    pub async fn clear(this: &StorageArea) -> Result<JsValue, JsValue>;
 }
 
 #[wasm_bindgen]
@@ -50,16 +35,16 @@ extern "C" {
     pub type Storage;
 
     #[wasm_bindgen(method, getter)]
-    pub fn sync(this: &Storage) -> Sync;
+    pub fn sync(this: &Storage) -> StorageArea;
 
     #[wasm_bindgen(method, getter)]
-    pub fn local(this: &Storage) -> Local;
+    pub fn local(this: &Storage) -> StorageArea;
 
     #[wasm_bindgen(method, getter)]
-    pub fn session(this: &Storage) -> SessionStorage;
+    pub fn session(this: &Storage) -> StorageArea;
 
     #[wasm_bindgen(method, getter)]
-    pub fn managed(this: &Storage) -> Managed;
+    pub fn managed(this: &Storage) -> StorageAreaRead;
 
     #[wasm_bindgen(method, getter, js_name = onChanged)]
     pub fn on_changed(this: &Storage) -> EventTarget;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -38,6 +38,9 @@ extern "C" {
     #[wasm_bindgen(extends = StorageAreaWrite)]
     pub type Local;
 
+    #[wasm_bindgen(extends = StorageAreaWrite)]
+    pub type SessionStorage;
+
     #[wasm_bindgen(extends = StorageAreaRead)]
     pub type Managed;
 }
@@ -51,6 +54,9 @@ extern "C" {
 
     #[wasm_bindgen(method, getter)]
     pub fn local(this: &Storage) -> Local;
+
+    #[wasm_bindgen(method, getter)]
+    pub fn session(this: &Storage) -> SessionStorage;
 
     #[wasm_bindgen(method, getter)]
     pub fn managed(this: &Storage) -> Managed;


### PR DESCRIPTION
- Adds the missing `storage.session`
- Combines common storage types to simplify their use
  + `StorageAreaWrite` and its extensions (`Sync`/`Local`/`SessionStorage`) → StorageArea
  + `StorageAreaRead` extension (`Managed`) → StorageAreaRead

Closes #23