### PR TITLE
Add onInstall, setUninstallURL methods to runtime

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -23,6 +23,14 @@ extern "C" {
     #[wasm_bindgen(method, getter, js_name = onConnect)]
     pub fn on_connect(this: &Runtime) -> EventTarget;
 
+    #[wasm_bindgen(method, getter, js_name = onInstalled)]
+    pub fn on_installed(this: &Runtime) -> EventTarget;
+
+    #[wasm_bindgen(method, js_name = setUninstallURL)]
+    pub fn set_uninstall_url(this: &Runtime, url: &str);
+
     #[wasm_bindgen(method, js_name = openOptionsPage)]
     pub fn open_options_page(this: &Runtime);
+
+
 }


### PR DESCRIPTION
https://developer.chrome.com/docs/extensions/reference/runtime/#event-onInstalled

Question: should https://developer.chrome.com/docs/extensions/reference/runtime/#type-OnInstalledReason be incorporated into this? Or is that outside of the scope of this crate?

Disclaimer: I am not a real rustacean 🦀 