### PR TITLE
add runtime.sendNativeMessage

### DIFF
--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -14,6 +14,13 @@ extern "C" {
         options: Option<&Object>,
     ) -> Result<JsValue, JsValue>;
 
+    #[wasm_bindgen(catch, method, js_name = sendNativeMessage)]
+    pub async fn send_native_message(
+        this: &Runtime,
+        application: &str,
+        message: &Object,
+    ) -> Result<JsValue, JsValue>;
+
     #[wasm_bindgen(method)]
     pub fn connect(this: &Runtime, extension_id: Option<&str>, connect_info: &Object) -> Port;
 


### PR DESCRIPTION
Adds `runtime.sendNativeMessage`

- https://developer.chrome.com/docs/extensions/reference/runtime/#method-sendNativeMessage
- https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/sendNativeMessage